### PR TITLE
Tanya delete task path scrum 67

### DIFF
--- a/src/components/DeleteTaskModal/DeleteTaskModal.jsx
+++ b/src/components/DeleteTaskModal/DeleteTaskModal.jsx
@@ -1,0 +1,57 @@
+/* eslint-disable react/prop-types */
+import { useState } from "react";
+import { toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
+
+
+const DeleteTaskModal = ({ activeTask, onRemoveTask, setOpenSettings, setOpenDeleteModal }) => {
+    const [activeButton, setActiveButton] = useState(false);
+    const [openTooltip, setOpenTooltip] = useState(false);
+
+
+    const handleClear = (e) => {
+        e.preventDefault();
+        setTaskName('');
+        setActiveButton(true);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter'
+            && taskName !== ""
+            && (editedSpoons - spoons) >= 0
+            && taskName !== " ") {
+            handleSubmit(e);
+        }
+    }
+
+    const handleSubmit = (e) => {
+        onRemoveTask(activeTask.id)
+        setOpenSettings(false);
+    }
+
+    const handleOpenTooltip = (e) => {
+        e.preventDefault();
+        if (openTooltip === false) {
+            setOpenTooltip(true)
+        } else {
+            setOpenTooltip(false)
+        }
+    }
+
+    return (
+        <section className=" w-[100vw] h-[100vh] flex justify-center items-center fixed top-0" onClick={() => setOpenDeleteModal(false)}>
+            <article className="center-column bg-background w-[328px] h-[234px] p-6 rounded-4xl flex-shrink-0" onClick={e => e.stopPropagation()}>
+                <div className="w-[100%] flex justify-between items-center border-b border-text3 pb-2">
+                    <h4 className="text-header4">Delete Task</h4>
+                </div>
+                <p className="text-body py-6 w-full">Are you sure you want to delete this task?</p>
+                <div className="flex justify-end gap-2">
+                    <button className="btn-modal" onClick={() => setOpenDeleteModal(false)}>Cancel</button>
+                    <button onClick={handleSubmit} className="btn-modal text-primary-text">Delete</button>
+                </div>
+            </article>
+        </section>
+    )
+}
+
+export default DeleteTaskModal;

--- a/src/components/DeleteTaskModal/DeleteTaskModal.jsx
+++ b/src/components/DeleteTaskModal/DeleteTaskModal.jsx
@@ -39,8 +39,8 @@ const DeleteTaskModal = ({ activeTask, onRemoveTask, setOpenSettings, setOpenDel
     }
 
     return (
-        <section className=" w-[100vw] h-[100vh] flex justify-center items-center fixed top-0" onClick={() => setOpenDeleteModal(false)}>
-            <article className="center-column bg-background w-[328px] h-[234px] p-6 rounded-4xl flex-shrink-0" onClick={e => e.stopPropagation()}>
+        <section className="bg-text2 w-[100vw] h-[100vh] flex justify-center items-center fixed top-0" onClick={() => setOpenDeleteModal(false)}>
+            <article className="bg-background w-[328px] h-[234px] p-6 rounded-4xl flex-shrink-0" onClick={e => e.stopPropagation()}>
                 <div className="w-[100%] flex justify-between items-center border-b border-text3 pb-2">
                     <h4 className="text-header4">Delete Task</h4>
                 </div>

--- a/src/components/TaskSettingsModal/TaskSettingsModal.jsx
+++ b/src/components/TaskSettingsModal/TaskSettingsModal.jsx
@@ -5,7 +5,7 @@ import EditTaskModal from "../EditTaskModal/EditTaskModal";
 
 
 
-const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handleTaskEdited}) => {
+const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handleTaskEdited, onRemoveTask}) => {
     const [openEditModal, setOpenEditModal] = useState(false)
 
     return (
@@ -27,7 +27,7 @@ const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handle
                         </svg>
                         Edit
                     </button>
-                    <button className="btn-settings">
+                    <button className="btn-settings" onClick={() => onRemoveTask(activeTask.id)}>
                         <svg xmlns="http://www.w3.org/2000/svg" width="19" height="18" viewBox="0 0 19 18" fill="none">
                             <path d="M12.5 6.75V14.25H6.5V6.75H12.5ZM11.375 2.25H7.625L6.875 3H4.25V4.5H14.75V3H12.125L11.375 2.25ZM14 5.25H5V14.25C5 15.075 5.675 15.75 6.5 15.75H12.5C13.325 15.75 14 15.075 14 14.25V5.25Z" fill="black"/>
                         </svg>

--- a/src/components/TaskSettingsModal/TaskSettingsModal.jsx
+++ b/src/components/TaskSettingsModal/TaskSettingsModal.jsx
@@ -2,11 +2,13 @@
 import { useState } from "react";
 import { createPortal } from "react-dom";
 import EditTaskModal from "../EditTaskModal/EditTaskModal";
+import DeleteTaskModal from "../DeleteTaskModal/DeleteTaskModal";
 
 
 
 const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handleTaskEdited, onRemoveTask}) => {
     const [openEditModal, setOpenEditModal] = useState(false)
+    const [openDeleteModal, setOpenDeleteModal] = useState(false)
 
     return (
         <section className="bg-text2 w-[100vw] h-[100vh] flex justify-center items-center fixed top-0" onClick={() => setOpenSettings(false)}>
@@ -27,7 +29,7 @@ const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handle
                         </svg>
                         Edit
                     </button>
-                    <button className="btn-settings" onClick={() => onRemoveTask(activeTask.id)}>
+                    <button className="btn-settings" onClick={() => setOpenDeleteModal(true)}>
                         <svg xmlns="http://www.w3.org/2000/svg" width="19" height="18" viewBox="0 0 19 18" fill="none">
                             <path d="M12.5 6.75V14.25H6.5V6.75H12.5ZM11.375 2.25H7.625L6.875 3H4.25V4.5H14.75V3H12.125L11.375 2.25ZM14 5.25H5V14.25C5 15.075 5.675 15.75 6.5 15.75H12.5C13.325 15.75 14 15.075 14 14.25V5.25Z" fill="black"/>
                         </svg>
@@ -42,6 +44,15 @@ const TaskSettingsModal = ({setOpenSettings, activeTask, remainingSpoons, handle
                     remainingSpoons={remainingSpoons}
                     activeTask={activeTask}
                     handleTaskEdited={handleTaskEdited}
+                />,
+                document.body
+            )}
+            {openDeleteModal && createPortal(
+                <DeleteTaskModal 
+                    setOpenDeleteModal={setOpenDeleteModal}
+                    setOpenSettings={setOpenSettings}
+                    activeTask={activeTask}
+                    onRemoveTask={onRemoveTask}
                 />,
                 document.body
             )}

--- a/src/pages/TasksPage/TasksPage.jsx
+++ b/src/pages/TasksPage/TasksPage.jsx
@@ -62,6 +62,7 @@ const TasksPage = ({remainingSpoons, taskList, setTaskList}) => {
         } else {
             setTaskRemoved(false)
         }
+        toast.success("Your task has been deleted successfully!", { theme: "colored", style : {backgroundColor: "#41993F", textAlign: 'center'}, toastId: "successEdit" });
     };
 
     const editChecked = (id) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🥝 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Description

This PR enables the user to delete a task after selecting the delete button. 

## Related Tickets & Documents
SCRUM-67

## Mobile & Desktop Screenshots/Recordings

<img width="388" alt="Screenshot 2023-11-15 at 3 37 39 PM" src="https://github.com/cherryontech/kiwi-kick-project/assets/76887085/5993f2d2-d430-4a96-8737-7907aa0542a1">

<img width="386" alt="Screenshot 2023-11-15 at 3 37 54 PM" src="https://github.com/cherryontech/kiwi-kick-project/assets/76887085/4398405e-d22b-4fed-a083-9484ec07f9dc">

<img width="386" alt="Screenshot 2023-11-15 at 6 48 35 PM" src="https://github.com/cherryontech/kiwi-kick-project/assets/76887085/95ac2296-03a7-4143-9c72-9bc6f907ca5e">

<img width="386" alt="Screenshot 2023-11-15 at 3 38 07 PM" src="https://github.com/cherryontech/kiwi-kick-project/assets/76887085/9585ebb2-cd33-464d-82c0-4967dc0904f7">


## Added to documentation?

- [ ] 📜 README.md
- [ ] 📜 CONTRIBUTING.md
- [ ] 📜 PULL_REQUEST_TEMPLATE.md
- [x] ✖️ no documentation needed

## Added tests?

- [ ] ✔️ yes
- [x] ✖️ no, testing will be added later
- [ ] ✖️ no, because they aren't needed
- [ ] ❓ no, because I need help


## How to test...

1. Navigate to the Netlify deploy preview
2. Add a task using the "Add Task" button on the bottom of the page
3. A card with the task will appear. The checkbox on the left of the card can be checked, or the card can be edited or deleted with the three dots icon on the right.
4. After clicking on the three button icon, a modal will appear with two buttons: edit and delete. 
5. To test this PR, select the delete button. This will show a confirmation dialog that asks the user if they want to delete the task. If the user clicks "delete" the task is deleted. If not, the user is taken back to the edit and delete modal. 

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.

  Attribution: This PR template was modified and sourced from the OpenSauced team, 
  see https://dev.to/opensauced/how-to-create-a-good-pull-request-template-and-why-you-should-add-gifs-4i0l for further details.
-->