### PR TITLE
Kat responsive home page scrum 98

### DIFF
--- a/src/components/AddTaskModal/AddTaskModal.jsx
+++ b/src/components/AddTaskModal/AddTaskModal.jsx
@@ -217,7 +217,7 @@ const AddTaskModal = ({ setShowModal, remainingSpoons, handleTaskAdded }) => {
                     <div className="relative pb-4">
                         <h5 className="text-subtitle mb-1">Assign priority</h5>
                         <div>
-                            <button className={`bg-${backgroundColors[selectedPriority]} w-[151px] flex justify-between items-center text-body text-text1 border-[1px] border-text3 px-4 py-[10px] rounded-lg`} onClick={handleOpenDropdown}>
+                            <button className={`bg-${backgroundColors[selectedPriority]} w-[151px] flex justify-between items-center text-body border-[1px] border-text3 px-4 py-[10px] rounded-lg`} onClick={handleOpenDropdown}>
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M14 3.00001V10.5C13.9996 10.5712 13.984 10.6415 13.9543 10.7061C13.9245 10.7708 13.8813 10.8284 13.8275 10.875C12.8725 11.7019 11.9594 12 11.0887 12C9.90687 12 8.80312 11.4538 7.77625 10.9469C6.11687 10.125 4.67438 9.41314 3 10.7356V13.5C3 13.6326 2.94732 13.7598 2.85355 13.8536C2.75979 13.9473 2.63261 14 2.5 14C2.36739 14 2.24021 13.9473 2.14645 13.8536C2.05268 13.7598 2 13.6326 2 13.5V3.00001C2.00048 2.92878 2.01617 2.85847 2.04603 2.7938C2.07589 2.72913 2.11922 2.67158 2.17313 2.62501C4.42313 0.676263 6.4425 1.67439 8.2225 2.55501C9.9375 3.40376 11.4244 4.13751 13.1725 2.62501C13.2448 2.56238 13.3335 2.52178 13.4281 2.50802C13.5227 2.49427 13.6193 2.50793 13.7064 2.5474C13.7935 2.58687 13.8674 2.65049 13.9195 2.73071C13.9715 2.81093 13.9995 2.90439 14 3.00001Z" fill="#001111" fillOpacity="0.75"/>
                                 </svg>
@@ -226,7 +226,7 @@ const AddTaskModal = ({ setShowModal, remainingSpoons, handleTaskAdded }) => {
                                     <path fillRule="evenodd" clipRule="evenodd" d="M20.625 9L12.625 17L4.625 9L6.625 7L12.625 13L18.625 7L20.625 9Z" fill="#001111" fillOpacity="0.75"/>
                                 </svg>
                             </button>
-                            <ul className={openDropdown? "absolute top-[75px] w-[151px] rounded-lg bg-background text-body text-text1" : "hidden"}>
+                            <ul className={openDropdown? "absolute top-[75px] w-[151px] rounded-lg bg-background text-body" : "hidden"}>
                                 <li>
                                     <button value="High" onClick={handleSelectedPriority} className="w-full text-start bg-primary1 px-2 py-2.5 hover:bg-primary-text focus:bg-primary-text focus:outline-none">High</button>
                                 </li>

--- a/src/components/AddTaskModal/AddTaskModal.jsx
+++ b/src/components/AddTaskModal/AddTaskModal.jsx
@@ -217,7 +217,7 @@ const AddTaskModal = ({ setShowModal, remainingSpoons, handleTaskAdded }) => {
                     <div className="relative pb-4">
                         <h5 className="text-subtitle mb-1">Assign priority</h5>
                         <div>
-                            <button className={`bg-${backgroundColors[selectedPriority]} w-[151px] flex justify-between items-center text-body border-[1px] border-text3 px-4 py-[10px] rounded-lg`} onClick={handleOpenDropdown}>
+                            <button className={`bg-${backgroundColors[selectedPriority]} w-[151px] flex justify-between items-center text-body border-[1px] border-text3 px-4 py-[10px] rounded-lg text-text1`} onClick={handleOpenDropdown}>
                                 <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
                                     <path d="M14 3.00001V10.5C13.9996 10.5712 13.984 10.6415 13.9543 10.7061C13.9245 10.7708 13.8813 10.8284 13.8275 10.875C12.8725 11.7019 11.9594 12 11.0887 12C9.90687 12 8.80312 11.4538 7.77625 10.9469C6.11687 10.125 4.67438 9.41314 3 10.7356V13.5C3 13.6326 2.94732 13.7598 2.85355 13.8536C2.75979 13.9473 2.63261 14 2.5 14C2.36739 14 2.24021 13.9473 2.14645 13.8536C2.05268 13.7598 2 13.6326 2 13.5V3.00001C2.00048 2.92878 2.01617 2.85847 2.04603 2.7938C2.07589 2.72913 2.11922 2.67158 2.17313 2.62501C4.42313 0.676263 6.4425 1.67439 8.2225 2.55501C9.9375 3.40376 11.4244 4.13751 13.1725 2.62501C13.2448 2.56238 13.3335 2.52178 13.4281 2.50802C13.5227 2.49427 13.6193 2.50793 13.7064 2.5474C13.7935 2.58687 13.8674 2.65049 13.9195 2.73071C13.9715 2.81093 13.9995 2.90439 14 3.00001Z" fill="#001111" fillOpacity="0.75"/>
                                 </svg>
@@ -228,13 +228,13 @@ const AddTaskModal = ({ setShowModal, remainingSpoons, handleTaskAdded }) => {
                             </button>
                             <ul className={openDropdown? "absolute top-[75px] w-[151px] rounded-lg bg-background text-body" : "hidden"}>
                                 <li>
-                                    <button value="High" onClick={handleSelectedPriority} className="w-full text-start bg-primary1 px-2 py-2.5 hover:bg-primary-text focus:bg-primary-text focus:outline-none">High</button>
+                                    <button value="High" onClick={handleSelectedPriority} className="w-full text-start bg-primary1 px-2 py-2.5 hover:bg-primary-text focus:bg-primary-text focus:outline-none text-text1">High</button>
                                 </li>
                                 <li>
-                                    <button value="Medium" onClick={handleSelectedPriority} className="w-full text-start bg-primary3 px-2 py-2.5 hover:bg-primary focus:bg-primary focus:outline-none">Medium</button>
+                                    <button value="Medium" onClick={handleSelectedPriority} className="w-full text-start bg-primary3 px-2 py-2.5 hover:bg-primary focus:bg-primary focus:outline-none text-text1">Medium</button>
                                 </li>
                                 <li>
-                                    <button value="Low" onClick={handleSelectedPriority} className=" w-full text-start bg-primary4 px-2 py-2.5 hover:bg-primary1 focus:bg-primary1 focus:outline-none">Low</button>
+                                    <button value="Low" onClick={handleSelectedPriority} className=" w-full text-start bg-primary4 px-2 py-2.5 hover:bg-primary1 focus:bg-primary1 focus:outline-none text-text1">Low</button>
                                 </li>
                             </ul>
                         </div>

--- a/src/components/AddTaskModal/AddTaskModal.test.jsx
+++ b/src/components/AddTaskModal/AddTaskModal.test.jsx
@@ -7,7 +7,7 @@ describe("AddTaskModal", () => {
     it("add button is disabled on load", () => {
         render(<AddTaskModal />);
         const button = screen.getAllByRole("button");
-        expect(button[2]).toHaveAttribute("disabled");
+        expect(button[7]).toHaveAttribute("disabled");
     })
 
     it("clear button is not disabled", () => {
@@ -39,7 +39,7 @@ describe("AddTaskModal", () => {
 
     it("should be able to type in spoon input field", () => {
         render(<AddTaskModal />);
-        const inputField = screen.getByPlaceholderText("00");
+        const inputField = screen.getByPlaceholderText("0");
         fireEvent.change(inputField, { target: { value: "12"}});
         expect(inputField.value).toBe("12");
     })

--- a/src/components/TaskCard/TaskCard.jsx
+++ b/src/components/TaskCard/TaskCard.jsx
@@ -20,7 +20,7 @@ const TaskCard = ({ task, onRemoveTask, editChecked, remainingSpoons, handleTask
     }
 
     return (
-        <div className="w-full p-1">
+        <div className="w-full py-1">
             <div className={`bg-${task.background} shadow-card-shadow rounded-lg flex items-start justify-between pl-4`}>
                 <div className="flex py-4 items-center">
                     <input

--- a/src/pages/TasksPage/TasksPage.jsx
+++ b/src/pages/TasksPage/TasksPage.jsx
@@ -118,7 +118,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
     }
 
     return (
-        <section className="bg-background w-[100vw] h-[100vh] p-4 md:p-6 xl:px-24 xl:py-4">
+        <section className="bg-background w-[100vw] h-[100vh] p-4 md:py-4 md:p-6 xl:px-24">
             <ToastContainer
                 position="top-center"
                 autoClose={3000}

--- a/src/pages/TasksPage/TasksPage.jsx
+++ b/src/pages/TasksPage/TasksPage.jsx
@@ -118,7 +118,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
     }
 
     return (
-        <section className="bg-background w-[100vw] h-[100vh] p-4">
+        <section className="bg-background w-[100vw] h-[100vh] p-4 md:p-6">
             <ToastContainer
                 position="top-center"
                 autoClose={3000}
@@ -139,28 +139,39 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                         <p className="text-caption text-text1 text-center w-[200px]">Plan your day by adding tasks and allocating your energy among them.</p>
                     </div>
                     :
-                    <div className="pt-2 pb-[100px]">
-                        <ul>
-                            {highPriorityTasks.map((task) => {
-                                return (
-                                    <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
-                                )
-                            })}
-                        </ul>
-                        <ul>
-                            {mediumPriorityTasks.map((task) => {
-                                return (
-                                    <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
-                                )
-                            })}
-                        </ul>
-                        <ul>
-                            {lowPriorityTasks.map((task) => {
-                                return (
-                                    <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
-                                )
-                            })}
-                        </ul>
+                    <div className="pt-2 pb-[100px] grid grid-cols-1 md:grid-cols-2 md:gap-x-6">
+                        <div>
+                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">High Priority</p>
+                            <ul>
+                                {highPriorityTasks.map((task) => {
+                                    return (
+                                        <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
+                                    )
+                                })}
+                            </ul>
+                        </div>
+                        <div>
+                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Medium Priority</p>
+                            <ul>
+                                {mediumPriorityTasks.map((task) => {
+                                    return (
+                                        <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
+                                    )
+                                })}
+                            </ul>
+                        </div>
+                        <div>
+                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Low Priority</p>
+                            <ul>
+                                {lowPriorityTasks.map((task) => {
+                                    return (
+                                        <li key={task.id}> <TaskCard task={task} onRemoveTask={removeTask} editChecked={editChecked} remainingSpoons={remainingSpoons} handleTaskEdited={handleTaskEdited} /></li>
+                                    )
+                                })}
+                            </ul>
+                        </div>
+                       <div>
+                        <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Other Tasks</p>
                         <ul>
                             {noPriorityTasks.map((task) => {
                                 return (
@@ -168,10 +179,11 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                                 )
                             })}
                         </ul>
+                       </div>
                     </div>
 
             }
-            <button className="flex gap-3 fixed bottom-px right-px p-4 m-4 shadow-box-shadow rounded-2xl bg-accent" onClick={openModal}>
+            <button className="flex gap-3 fixed bottom-px right-px p-4 m-4 md:mb-8 md:mx-6 shadow-box-shadow rounded-2xl bg-accent" onClick={openModal}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
                     <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" fill="#0F0129" />
                 </svg>

--- a/src/pages/TasksPage/TasksPage.jsx
+++ b/src/pages/TasksPage/TasksPage.jsx
@@ -118,7 +118,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
     }
 
     return (
-        <section className="bg-background w-[100vw] h-[100vh] p-4 md:p-6">
+        <section className="bg-background w-[100vw] h-[100vh] p-4 md:p-6 xl:px-24 xl:py-4">
             <ToastContainer
                 position="top-center"
                 autoClose={3000}
@@ -139,7 +139,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                         <p className="text-caption text-text1 text-center w-[200px]">Plan your day by adding tasks and allocating your energy among them.</p>
                     </div>
                     :
-                    <div className="pt-2 pb-[100px] grid grid-cols-1 md:grid-cols-2 md:gap-x-6">
+                    <div className="pt-2 pb-[100px] grid grid-cols-1 md:grid-cols-2 md:gap-x-6 xl:grid-cols-3 xl:gap-y-8">
                         <div>
                             <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">High Priority</p>
                             <ul>
@@ -183,7 +183,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                     </div>
 
             }
-            <button className="flex gap-3 fixed bottom-px right-px p-4 m-4 md:mb-8 md:mx-6 shadow-box-shadow rounded-2xl bg-accent" onClick={openModal}>
+            <button className="flex gap-3 fixed bottom-px right-px p-4 m-4 md:mb-8 md:mx-6 xl:mx-24 shadow-box-shadow rounded-2xl bg-accent" onClick={openModal}>
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none">
                     <path d="M19 13H13V19H11V13H5V11H11V5H13V11H19V13Z" fill="#0F0129" />
                 </svg>

--- a/src/pages/TasksPage/TasksPage.jsx
+++ b/src/pages/TasksPage/TasksPage.jsx
@@ -141,7 +141,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                     :
                     <div className="pt-2 pb-[100px] grid grid-cols-1 md:grid-cols-2 md:gap-x-6 xl:grid-cols-3 xl:gap-y-8">
                         <div>
-                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">High Priority</p>
+                            <p className="text-small-body md:text-subtitle text-text1 py-2 md:py-4">High Priority</p>
                             <ul>
                                 {highPriorityTasks.map((task) => {
                                     return (
@@ -151,7 +151,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                             </ul>
                         </div>
                         <div>
-                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Medium Priority</p>
+                            <p className="text-small-body md:text-subtitle text-text1 py-2 md:py-4">Medium Priority</p>
                             <ul>
                                 {mediumPriorityTasks.map((task) => {
                                     return (
@@ -161,7 +161,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                             </ul>
                         </div>
                         <div>
-                            <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Low Priority</p>
+                            <p className="text-small-body md:text-subtitle text-text1 py-2 md:py-4">Low Priority</p>
                             <ul>
                                 {lowPriorityTasks.map((task) => {
                                     return (
@@ -171,7 +171,7 @@ const TasksPage = ({ remainingSpoons, taskList, setTaskList }) => {
                             </ul>
                         </div>
                        <div>
-                        <p className="text-small-body md:text-subtitle text-text2 py-2 md:py-4">Other Tasks</p>
+                        <p className="text-small-body md:text-subtitle text-text1 py-2 md:py-4">Other Tasks</p>
                         <ul>
                             {noPriorityTasks.map((task) => {
                                 return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🥝 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [X] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] ⏩ Revert

## Description

This PR adds responsive layouts for the home page (Tasks Page) for tablet and desktop.

## Related Tickets & Documents
SCRUM 98

## Mobile & Desktop Screenshots/Recordings

Here is a Loom video: https://www.loom.com/share/90790bbbb83e4257b11719060c676b1a?sid=2fe9afdf-282c-4eef-8c03-d414a8c33b72

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📜 CONTRIBUTING.md
- [ ] 📜 PULL_REQUEST_TEMPLATE.md
- [X] ✖️ no documentation needed

## Added tests?

- [ ] ✔️ yes
- [ ] ✖️ no, testing will be added later
- [X] ✖️ no, because they aren't needed
- [ ] ❓ no, because I need help


## How to test...

1. Open the Netlify preview.
2. Change the size of the window.

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.
  
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.

  Attribution: This PR template was modified and sourced from the OpenSauced team, 
  see https://dev.to/opensauced/how-to-create-a-good-pull-request-template-and-why-you-should-add-gifs-4i0l for further details.
-->